### PR TITLE
Switch from include to include_tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,13 +1,16 @@
 ---
 
 - name: removes subscription nag box
-  include: remove-nag.yml
+  include_tasks:
+    file: remove-nag.yml
   when: remove_nag
 
 - name: remove enterprise repo
-  include: remove-enterprise-repo.yml
+  include_tasks:
+    file: remove-enterprise-repo.yml
   when: remove_enterprise_repo
 
 - name: add no subcription repo
-  include: add-no-subscription-repo.yml
+  include_tasks:
+    file: add-no-subscription-repo.yml
   when: add_no_subscription_repo


### PR DESCRIPTION
Addresses ansible-emitted deprecation notice for include action use.